### PR TITLE
feat: update docs to use published `floem` version

### DIFF
--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -1,0 +1,13 @@
+Currently, publishing is done manually. Simply,
+
+1. Create a new branch
+2. Bump the version and commit
+3. Run the following commands
+
+```
+cargo publish -p oxytail-base
+cargo publish -p oxytail-theme-dark
+cargo publish -p oxytail-theme-defaults
+```
+
+4. Merge the release branch 

--- a/README.md
+++ b/README.md
@@ -31,8 +31,7 @@ Next, add `oxytail-base`(to load a theme) and `oxytail-theme-dark`(or any other 
 
 ```toml
 [dependencies]
-
-floem = { git = "https://github.com/lapce/floem", rev = "e304d30f8771a28788904d64464d8fd192d07439" }
+floem = "0.1.1"
 oxytail-theme-dark = { git = "https://github.com/golota60/oxytail"}
 oxytail-base = { git = "https://github.com/golota60/oxytail"}
 ```

--- a/README.md
+++ b/README.md
@@ -22,21 +22,15 @@ Showcase:
 
 `oxytail` consists of the main "base" package(`oxytail-base`), which loads the theme you want, and theme packages(currently only `oxytail-theme-dark`. More coming soon!).
 
-Next, you need to choose your theme, and install it. Currently, `oxytail` comes with only one theme, `oxytail-theme-dark`, but if it doesn't suit your needs you can [write your own one](YOUR_OWN_THEME.md). It's still early days for this project, so some widgets are missing.
+Next, you need to choose your theme, and install it. Currently, `oxytail` comes with only one theme, `oxytail-theme-dark`, but if it doesn't suit your needs you can easily [write your own one](YOUR_OWN_THEME.md). It's still early days for this project, so some widgets are missing.
 
-First, add floem(floem is not on crates.io just yet, so we need to add it as a git dependency) dependency to your `Cargo.toml`.
+First, add `floem`, `oxytail-base`(to load a theme) and `oxytail-theme-dark`(or any other theme) 
 
-Next, add `oxytail-base`(to load a theme) and `oxytail-theme-dark`(or any other theme) also as a git dependency, since we rely on `floem`, which is not published.
-
-
-```toml
-[dependencies]
-floem = "0.1.1"
-oxytail-theme-dark = { git = "https://github.com/golota60/oxytail"}
-oxytail-base = { git = "https://github.com/golota60/oxytail"}
+```
+cargo add floem oxytail-base oxytail-theme-dark
 ```
 
-Done! Now, initialize the theme, and simply use `floem` like normal, *except* import your widgets from `oxytail-base` instead of `floem`!
+Done! Now, initialize the theme, and simply use `floem` like normal, *except* import your widgets from `oxytail-base` instead! You can't mix&match both `floem` and `oxytail` widgets as needed.
 
 ```rs
 use floem::kurbo::Size;

--- a/YOUR_OWN_THEME.md
+++ b/YOUR_OWN_THEME.md
@@ -18,8 +18,7 @@ You can specify colors and override those behaviors if needed.
 So, install `floem`, `oxytail-theme-defaults` and `oxytail-base`.
 ```toml
 [dependencies]
-# Please check README.md for the most up-to-date `rev` value!
-floem = { git = "https://github.com/lapce/floem", rev = "e304d30f8771a28788904d64464d8fd192d07439" 
+floem = "0.1.1"
 oxytail-base = { path = "../oxytail-base" }
 oxytail-theme-defaults = { path = "../oxytail-theme-defaults" }
 ```

--- a/YOUR_OWN_THEME.md
+++ b/YOUR_OWN_THEME.md
@@ -19,8 +19,8 @@ So, install `floem`, `oxytail-theme-defaults` and `oxytail-base`.
 ```toml
 [dependencies]
 floem = "0.1.1"
-oxytail-base = { path = "../oxytail-base" }
-oxytail-theme-defaults = { path = "../oxytail-theme-defaults" }
+oxytail-base = "0.1.0"
+oxytail-theme-defaults = "0.1.0"
 ```
 
 

--- a/examples/widget-gallery/Cargo.toml
+++ b/examples/widget-gallery/Cargo.toml
@@ -10,4 +10,4 @@ rust-version = "1.75"
 im = "15.1.0"
 oxytail-theme-dark = { path = "../../oxytail-theme-dark" }
 oxytail-base = { path = "../../oxytail-base" }
-floem = { git = "https://github.com/lapce/floem", rev = "e304d30f8771a28788904d64464d8fd192d07439" }
+floem = "0.1.1"

--- a/oxytail-base/Cargo.toml
+++ b/oxytail-base/Cargo.toml
@@ -9,5 +9,5 @@ rust-version = "1.75"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-floem = { git = "https://github.com/lapce/floem", rev = "e304d30f8771a28788904d64464d8fd192d07439" }
+floem = "0.1.1"
 

--- a/oxytail-theme-dark/Cargo.toml
+++ b/oxytail-theme-dark/Cargo.toml
@@ -9,6 +9,6 @@ rust-version = "1.75"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-floem = { git = "https://github.com/lapce/floem", rev = "e304d30f8771a28788904d64464d8fd192d07439" }
+floem = "0.1.1"
 oxytail-base = { path = "../oxytail-base" }
 oxytail-theme-defaults = { path = "../oxytail-theme-defaults" }

--- a/oxytail-theme-dark/Cargo.toml
+++ b/oxytail-theme-dark/Cargo.toml
@@ -11,4 +11,4 @@ rust-version = "1.75"
 [dependencies]
 floem = "0.1.1"
 oxytail-base = "0.1.0"
-oxytail-theme-defaults = { path = "../oxytail-theme-defaults" }
+oxytail-theme-defaults = "0.1.0"

--- a/oxytail-theme-dark/Cargo.toml
+++ b/oxytail-theme-dark/Cargo.toml
@@ -10,5 +10,5 @@ rust-version = "1.75"
 
 [dependencies]
 floem = "0.1.1"
-oxytail-base = { path = "../oxytail-base" }
+oxytail-base = "0.1.0"
 oxytail-theme-defaults = { path = "../oxytail-theme-defaults" }

--- a/oxytail-theme-defaults/Cargo.toml
+++ b/oxytail-theme-defaults/Cargo.toml
@@ -9,5 +9,5 @@ rust-version = "1.75"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-floem = { git = "https://github.com/lapce/floem", rev = "e304d30f8771a28788904d64464d8fd192d07439" }
+floem = "0.1.1"
 oxytail-base = { path = "../oxytail-base" }

--- a/oxytail-theme-defaults/Cargo.toml
+++ b/oxytail-theme-defaults/Cargo.toml
@@ -10,4 +10,4 @@ rust-version = "1.75"
 
 [dependencies]
 floem = "0.1.1"
-oxytail-base = { path = "../oxytail-base" }
+oxytail-base = "0.1.0"


### PR DESCRIPTION
- use https://crates.io/crates/floem instead of a git dep
- deploy all packages
- update docs